### PR TITLE
Added anwalt.de services AG to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Name | Website | City
 /gebrüderheitz | https://gebruederheitz.de/welcome | Mannheim
 abiturma GbR | https://www.abiturma.de | Weil der Stadt (Stuttgart)
 Actyx | https://www.actyx.io | Munich
+anwalt.de services AG | https://www.amwalt.de | Fully remote ; Offices in Nuremberg + Berlin
 BackHub | https://backhub.co | Freiburg
 Bayerischer Rundfunk | https://www.br.de | Munich
 Blacksquared | https://changers.com/ | Berlin


### PR DESCRIPTION
anwalt.de (around 100 ppl) is operating fully remote since March 2020 and will stay remote-first forever. We have offices in Nuremberg (HQ) and Berlin, and have people working from different cities in Germany (Cologne, Bremen) as well as people working from Brazil, Pakistan and Poland.