### PR TITLE
Add Ecosia

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Crate.io | https://crate.io/ | Berlin
 Cultured Code | https://culturedcode.com/things/ | Stuttgart
 digitalminds.io | https://www.digitalminds.io | Berlin
 easybill | https://www.easybill.de/ | Duesseldorf
+Ecosia | https://ecosia.org | Berlin
 Elastic | https://www.elastic.co/ | Berlin
 emetriq GmbH | https://www.emetriq.com/ | Hamburg
 ETECTURE | https://www.etecture.de | Frankfurt a.M. / Karlsruhe / Düsseldorf


### PR DESCRIPTION
Ecosia has multiple engineering teams with remote-first policy.
The head office is in Berlin, Germany, but the engineering team is spread across cities and countries.